### PR TITLE
Fix invalid attributes parameter passed into CRM_Core_Form::add()

### DIFF
--- a/CRM/Resource/Form/ResourceDemandCreate.php
+++ b/CRM/Resource/Form/ResourceDemandCreate.php
@@ -55,7 +55,7 @@ class CRM_Resource_Form_ResourceDemandCreate extends CRM_Core_Form
             'text',
             'resource_count',
             E::ts('Count'),
-            true,
+            [],
             true
         );
         $this->addRule('resource_count', E::ts('The demand should require a least one resource'), 'positiveInteger');

--- a/CRM/Resource/Form/ResourceDemandEdit.php
+++ b/CRM/Resource/Form/ResourceDemandEdit.php
@@ -46,7 +46,7 @@ class CRM_Resource_Form_ResourceDemandEdit extends CRM_Core_Form
             'text',
             'resource_count',
             E::ts('Count'),
-            true,
+            [],
             true
         );
         $this->addRule('resource_count', E::ts('The demand should require a least one resource'), 'positiveInteger');


### PR DESCRIPTION
This currently causes a `User deprecated function: Attributes passed to CRM_Core_Form::add() are not an array. Caller: CRM_Resource_Form_ResourceDemandEdit::buildQuickForm in CRM_Core_Error::deprecatedWarning() (line 1103 of docroot/vendor/civicrm/civicrm-core/CRM/Core/Error.php)` notice in the logs.

Passing `true` as `attributes` parameter does not make sense at all for `text` type fields, maybe that's a typo, @bjendres?