### PR TITLE
UX Improvements for the Attribute condition type

### DIFF
--- a/CRM/Resource/DemandCondition/Attribute.php
+++ b/CRM/Resource/DemandCondition/Attribute.php
@@ -46,7 +46,7 @@ class CRM_Resource_DemandCondition_Attribute extends CRM_Resource_BAO_ResourceDe
      *
      * @param CRM_Resource_BAO_ResourceDemand $resource_demand
      *   the resource demand
-     * 
+     *
      * @return string entity name
      */
     public static function getApi4Entity($resource_demand)
@@ -104,6 +104,9 @@ class CRM_Resource_DemandCondition_Attribute extends CRM_Resource_BAO_ResourceDe
      */
     public function isFulfilledWithResource($resource, &$error_messages = []) : bool
     {
+        $addOr = FALSE;
+        $clauseStatement = [];
+
         $params = $this->getParametersParsed();
         if (empty($params) || count($params) < 3) {
             Civi::log()->warning("Garbled parameters for condition [{$this->id}]");
@@ -111,16 +114,61 @@ class CRM_Resource_DemandCondition_Attribute extends CRM_Resource_BAO_ResourceDe
         }
         $entity_name = self::getApi4Entity($this->getResourceDemand());
         $attribute_name = $params[0];
+        // Fallback to distinguish the APIv3 custom field name
+        if (substr( $attribute_name, 0, 7) === "custom_") {
+          $customFieldID = substr($attribute_name, 7);
+          $field_specs = civicrm_api4($entity_name, 'getFields', [
+            'where' => [['custom_field_id', '=', $customFieldID]],
+          ]);
+          $field_spec = $field_specs->first();
+          // Set the proper attribute name
+          $attribute_name = $field_spec['name'];
+        }
         $attribute_value = $params[1];
         $attribute_operation = $params[2];
+        $sqlOp = self::getSQLOperator(html_entity_decode($attribute_operation));
+        // Rework for some operators
+        // In the case of multiselect customfields, we need to work on the attribute values first as the multiple values are being stored as a string with separators
+        switch ($sqlOp) {
+          case 'LIKE':
+          case 'NOT LIKE':
+            if ($attribute_operation == 'contains one or more' || $attribute_operation == 'not contains one or more') {
+              $addOr = TRUE;
+              foreach ($attribute_value as $atrKey) {
+                $attribute_value_tmp[] = '%' . CRM_Core_DAO::VALUE_SEPARATOR . $atrKey . CRM_Core_DAO::VALUE_SEPARATOR . '%';
+              }
+              $attribute_value = $attribute_value_tmp;
+            }
+            else {
+              $attribute_value = '%' . CRM_Core_DAO::VALUE_SEPARATOR . $attribute_value . CRM_Core_DAO::VALUE_SEPARATOR . '%';
+            }
+            break;
+        }
 
+        // Prepare the statement
         $resources = \Civi\Api4\Resource::get()
             ->setJoin([["{$entity_name} AS entity", TRUE, NULL, ['entity_id', '=', 'entity.id']]])
-            ->addWhere("entity.{$attribute_name}", $attribute_operation, $attribute_value)
             ->addWhere("id", '=', $resource->id)
-            ->setLimit(1)
-            ->execute();
-        $count = $resources->count();
+            ->setLimit(1);
+
+        if ($addOr && is_array($attribute_value)) {
+          foreach ($attribute_value as $atrKey) {
+            $clauseStatement[] = ["entity.{$attribute_name}", $sqlOp, $atrKey];
+          }
+          if ($sqlOp == 'NOT LIKE') {
+            $resources->addClause('AND', $clauseStatement);
+          }
+          else {
+            $resources->addClause('OR', $clauseStatement);
+          }
+
+        }
+        else {
+          $resources->addWhere("entity.{$attribute_name}", $sqlOp, $attribute_value);
+        }
+
+        // Execute the statement
+        $count = $resources->execute()->count();
         return $count > 0;
     }
 
@@ -132,17 +180,48 @@ class CRM_Resource_DemandCondition_Attribute extends CRM_Resource_BAO_ResourceDe
         // todo: improve
         $params = $this->getParametersParsed();
 
+        $optionLabel = $params[1];
+        $showOptions = FALSE;
+
         $entity_name = self::getApi4Entity($this->getResourceDemand());
-        $field_specs = civicrm_api4($entity_name, 'getFields', [
-            'where' => [['name', '=', $params[0]]]
-        ]);
+        // Workaround to support lookup on customfields coming as `custom_xxx`
+        if (substr( $params[0], 0, 7) === "custom_") {
+          $customFieldID = substr($params[0], 7);
+          $field_specs = civicrm_api4($entity_name, 'getFields', [
+            'where' => [['custom_field_id', '=', $customFieldID]],
+            'loadOptions' => TRUE,
+          ]);
+          $showOptions = TRUE;
+        }
+        else {
+          $field_specs = civicrm_api4($entity_name, 'getFields', [
+            'where' => [['name', '=', $params[0]]],
+          ]);
+        }
         $field_spec = $field_specs->first();
+
+        // Prepare to display the optionvalue labels
+        if ($showOptions) {
+          if (is_array($params[1])) {
+            $optionLabel = [];
+            foreach ($params[1] as $ov) {
+              if (array_key_exists($ov, $field_spec['options'])) {
+                $optionLabel[] = $field_spec['options'][$ov];
+              }
+            }
+          }
+          else {
+            if (array_key_exists($params[1], $field_spec['options'])) {
+              $optionLabel = $field_spec['options'][$params[1]];
+            }
+          }
+        }
 
         return E::ts("Attribute \"%1\" <code>%2</code> \"%3\"",
             [
                 1 => $field_spec['label'],
                 2 => $params[2],
-                3 => trim(json_encode($params[1]), '"'),
+                3 => trim(json_encode($optionLabel), '"'),
             ]
         );
     }
@@ -173,24 +252,31 @@ class CRM_Resource_DemandCondition_Attribute extends CRM_Resource_BAO_ResourceDe
         $entity_name = self::getApi4Entity($demand_bao);
         $field_specs = civicrm_api4($entity_name, 'getFields');
         foreach ($field_specs->getIterator() as $field_spec) {
+          // As we are not ready yet on the APIv4 on the frontend side, we need
+          // to convert the Customfieldgroup.customfieldname to custom_xxx.customfieldname
+          if ($field_spec['type'] == 'Custom') {
+            $field_names["custom_" . $field_spec['custom_field_id']] = $field_spec['title'];
+          }
+          else {
             $field_names[$field_spec['name']] = $field_spec['title'];
+          }
         }
 
-        // todo: pull? label? translate?
         $operators = [
-            '=' => '=',
-            '<=' => '<=',
-            '>=' => '>=',
-            '>' => '>',
-            '<' => '<',
-            'LIKE' => 'LIKE',
-            '<>' => '<>',
-            'NOT LIKE' => 'NOT LIKE',
-            'IN' => 'IN',
-            'NOT IN' => 'NOT IN',
-            'IS NULL' => 'IS NULL',
-            'IS NOT NULL' => 'IS NOT NULL',
-            'CONTAINS' => 'CONTAINS',
+          '=' => E::ts('Is equal to'),
+          '!=' => E::ts('Is not equal to'),
+          '>' => E::ts('Is greater than'),
+          '<' => E::ts('Is less than'),
+          '>=' => E::ts('Is greater than or equal to'),
+          '<=' => E::ts('Is less than or equal to'),
+          'contains string' => E::ts('Contains string (case insensitive)'),
+          'contains one or more' => E::ts('Contains one or more string(s) (case insensitive)'),
+          'not contains string' => E::ts('Does not contain string (case insensitive)'),
+          'not contains one or more' => E::ts('Does not contain one or more string(s) (case insensitive)'),
+          'is empty' => E::ts('Is empty'),
+          'is not empty' => E::ts('Is not empty'),
+          'is one of' => E::ts('Is one of'),
+          'is not one of' => E::ts('Is not one of'),
         ];
 
         $form->add(
@@ -211,19 +297,14 @@ class CRM_Resource_DemandCondition_Attribute extends CRM_Resource_BAO_ResourceDe
             ['class' => 'crm-select2']
         );
 
-        // add date
-        $form->add(
-            'text',
-            $prefix . '_value',
-            E::ts("Value"),
-            NULL,
-            FALSE,
-            []);
+        $form->add('text', $prefix . '_value', E::ts('Value'), NULL, FALSE);
+        $form->add('textarea', $prefix . '_multi_value', E::ts('Values'));
 
         return [
             $prefix . '_field_name',
             $prefix . '_operator',
             $prefix . '_value',
+            $prefix . '_multi_value',
         ];
     }
 
@@ -256,12 +337,109 @@ class CRM_Resource_DemandCondition_Attribute extends CRM_Resource_BAO_ResourceDe
      */
     public static function compileParameters($data, $prefix = '')
     {
+      $isMultiple = self::getEntryType($data["{$prefix}_operator"]);
+      if ($isMultiple) {
+        if (array_key_exists("{$prefix}_multi_value", $data) && !empty($data["{$prefix}_multi_value"])) {
+          $dataValues = preg_split('/\n|\r\n?/', $data["{$prefix}_multi_value"]);
+        }
+        else {
+
+        }
+      }
+      else {
+        $dataValues = $data["{$prefix}_value"];
+      }
+
         // format the from/to values properly
         return [
             $data["{$prefix}_field_name"],
-            $data["{$prefix}_value"],
+            $dataValues,
             $data["{$prefix}_operator"],
         ];
+    }
+
+    /**
+     * getEntryType
+     * Identifies if the field is multiple or single
+     *
+     * @param  mixed $op
+     * @return bool
+     */
+    private function getEntryType($Op) {
+      $isMultiple = FALSE;
+
+      $operators = [
+        '=' => E::ts('Is equal to'),
+        '!=' => E::ts('Is not equal to'),
+        '>' => E::ts('Is greater than'),
+        '<' => E::ts('Is less than'),
+        '>=' => E::ts('Is greater than or equal to'),
+        '<=' => E::ts('Is less than or equal to'),
+        'contains string' => E::ts('Contains string (case insensitive)'),
+        'not contains string' => E::ts('Does not contain string (case insensitive)'),
+        'is empty' => E::ts('Is empty'),
+        'is not empty' => E::ts('Is not empty'),
+        'is one of' => E::ts('Is one of'),
+        'is not one of' => E::ts('Is not one of'),
+        'contains one or more' => E::ts('Contains one or more string(s) (case insensitive)'),
+        'not contains one or more' => E::ts('Does not contain one or more string(s) (case insensitive)'),
+      ];
+      if ($Op) {
+        switch ($Op) {
+          case 'is one of':
+          case 'is not one of':
+          case 'contains one or more':
+          case 'not contains one or more':
+            $isMultiple = TRUE;
+            break;
+
+          case 'is empty':
+          case 'is not empty':
+            $isMultiple = FALSE;
+            break;
+
+          default:
+            $isMultiple = FALSE;
+          break;
+
+        }
+      }
+      return $isMultiple;
+
+    }
+
+    /**
+     * getSQLOperator
+     * Converts the text operator to SQL operator
+     *
+     * @param  mixed $op
+     * @return string
+     */
+    private function getSQLOperator($op) {
+      $sqlOp = $op;
+
+        $operators = [
+          '=' => '=',
+          '!=' => '!=',
+          '>' => '>',
+          '<' => '<',
+          '>=' => '>=',
+          '<=' => '<=',
+          'contains string' => 'LIKE',
+          'contains one or more' => 'LIKE',
+          'not contains string' => 'NOT LIKE',
+          'not contains one or more' => 'NOT LIKE',
+          'is empty' => 'IS NULL',
+          'is not empty' => 'IS NOT NULL',
+          'is one of' => 'IN',
+          'is not one of' => 'NOT IN',
+        ];
+        if (array_key_exists($op, $operators)) {
+          $sqlOp = $operators[$op];
+        }
+
+        return $sqlOp;
+
     }
 
     /**
@@ -276,14 +454,35 @@ class CRM_Resource_DemandCondition_Attribute extends CRM_Resource_BAO_ResourceDe
     public function getCurrentFormValues($prefix = '')
     {
         $params = $this->getParametersParsed();
+        $defaults = [];
 
         if (isset($params[2])) {
-            return [
-                "{$prefix}_field_name" => $params[0],
-                "{$prefix}_value"      => $params[1],
-                "{$prefix}_operator"   => $params[2],
+          $opType = self::getEntryType($params[2]);
+          // Check the value
+          if ($opType) {
+            if (is_array($params[1])) {
+              $dataValue = implode("\r\n", $params[1]);
+              $defaults = [
+                "{$prefix}__field_name"  => $params[0],
+                "{$prefix}__value"       => NULL,
+                "{$prefix}__multi_value" => $dataValue,
+                "{$prefix}__operator"    => $params[2],
+                "condition_type"        => $prefix,
+              ];
+            }
+          }
+          else {
+            $defaults = [
+              "{$prefix}__field_name"  => $params[0],
+              "{$prefix}__value"       => $params[1],
+              "{$prefix}__multi_value" => NULL,
+              "{$prefix}__operator"    => $params[2],
+              "condition_type"        => $prefix,
             ];
-        } else {
+          }
+            return $defaults;
+        }
+        else {
             return [];
         }
     }

--- a/CRM/Resource/Form/Condition.php
+++ b/CRM/Resource/Form/Condition.php
@@ -48,6 +48,12 @@ class CRM_Resource_Form_Condition extends CRM_Core_Form
         }
         $this->assign('type_fields', $type_fields);
 
+        $excludeLabelsPerID = [
+          'CRM_Resource_DemandCondition_Attribute__value',
+          'CRM_Resource_DemandCondition_Attribute__multi_value',
+        ];
+        $this->assign('exclude_labels', $excludeLabelsPerID);
+
         $this->add(
             'select',
             'condition_type',
@@ -66,6 +72,7 @@ class CRM_Resource_Form_Condition extends CRM_Core_Form
           ]);
 
         Civi::resources()->addScriptFile(E::LONG_NAME, 'js/condition_create.js', 10, 'page-header');
+        Civi::resources()->addScriptFile(E::LONG_NAME, 'js/condition_rules.js', 10, 'page-header');
 
         parent::buildQuickForm();
     }

--- a/js/condition_rules.js
+++ b/js/condition_rules.js
@@ -1,0 +1,204 @@
+(function ($, _, ts) {
+  $(document).ready(function () {
+    $('#CRM_Resource_DemandCondition_Attribute__operator').change(function() {
+      var val = $('#CRM_Resource_DemandCondition_Attribute__operator').val();
+      var isMultiple = false;
+      switch (val) {
+        case 'is one of':
+        case 'is not one of':
+        case 'contains one or more':
+        case 'not contains one or more':
+          $('#value_parent').addClass('hiddenElement');
+          $('#multi_value_parent').removeClass('hiddenElement');
+          isMultiple = true;
+          break;
+
+        case 'is empty':
+        case 'is not empty':
+          $('#value_parent').addClass('hiddenElement');
+          $('#multi_value_parent').addClass('hiddenElement');
+          isMultiple = false;
+          break;
+
+        default:
+          $('#value_parent').removeClass('hiddenElement');
+          $('#multi_value_parent').addClass('hiddenElement');
+          isMultiple = false;
+          break;
+      }
+    });
+
+    function retrieveOptionsForEntityAndField(entity, field) {
+      var options = new Array();
+      var multiple = false;
+      resource_updateOptionValues(options, multiple);
+      CRM.api3(entity, 'getoptions', {'sequential': 1, 'field': field}, false)
+      .done(function (data) {
+        if (data.values) {
+          options = data.values;
+        }
+
+        if (field.indexOf('custom_') == 0) {
+          var custom_field_id = field.replace('custom_', '');
+          CRM.api3('CustomField', 'getsingle', {'sequential': 1, 'id': custom_field_id}, true)
+          .done(function(data) {
+            switch(data.html_type) {
+              case 'CheckBox':
+              case 'Multi-Select':
+              case 'AdvMulti-Select':
+                multiple = true;
+                resource_updateOptionValues(options, multiple);
+                break;
+
+              default:
+                resource_updateOptionValues(options, multiple);
+                break;
+
+            }
+          });
+        } else {
+          resource_updateOptionValues(options, multiple);
+        }
+      });
+
+    }
+
+    function resource_form_resetOptions () {
+      $('#multi_value_options').html('');
+      $('#value_options').html('');
+      $('#multi_value_options').addClass('hiddenElement');
+      $('#multi_value_parent .content.textarea').removeClass('hiddenElement');
+      $('#value_options').addClass('hiddenElement');
+      $('#value').removeClass('hiddenElement');
+    }
+
+    function resource_form_updateOperator (options, multiple) {
+      if (!resource_form_initialOperator) {
+        resource_form_initialOperator = $('#operator').val();
+      }
+      $('#operator option').removeClass('hiddenElement');
+      if (options.length) {
+          $('#operator option[value=">"').addClass('hiddenElement');
+          $('#operator option[value=">="').addClass('hiddenElement');
+          $('#operator option[value="<"').addClass('hiddenElement');
+          $('#operator option[value="<="').addClass('hiddenElement');
+          $('#operator option[value="contains string"').addClass('hiddenElement');
+          $('#operator option[value="not contains string"').addClass('hiddenElement');
+      }
+      if (options.length && multiple) {
+          $('#operator option[value="="').addClass('hiddenElement');
+          $('#operator option[value="!="').addClass('hiddenElement');
+          $('#operator option[value="is one of"').addClass('hiddenElement');
+          $('#operator option[value="is not one of"').addClass('hiddenElement');
+          $('#operator option[value="contains one or more"').addClass('hiddenElement');
+          $('#operator option[value="not contains one or more"').addClass('hiddenElement');
+
+      }
+      else {
+
+      }
+      if ($('#operator option:selected').hasClass('hiddenElement')) {
+
+          if (!$('#operator option[value="'+resource_form_initialOperator+'"]').hasClass('hiddenElement')) {
+              $('#operator option[value="'+resource_form_initialOperator+'"]').prop('selected', true);
+          } else {
+              $('#operator option:not(.hiddenElement)').first().prop('selected', true);
+          }
+          $('#operator option:not(.hiddenElement)').first().prop('selected', true);
+          $('#operator').trigger('change');
+      }
+    }
+
+    function resource_updateOptionValues(options, multiple) {
+      resource_form_resetOptions();
+      resource_form_updateOperator(options, multiple);
+      if (options && options.length > 0) {
+        var select_options = '';
+        var multi_select_options = '';
+
+        var currentSelectedOptions = $('#CRM_Resource_DemandCondition_Attribute__multi_value').html().match(/[^\r\n]+/g);
+        var currentSelectedOption = $('#CRM_Resource_DemandCondition_Attribute__value').val();
+        var selectedOptions = new Array();
+        var selectedOption = '';
+        if (!currentSelectedOptions) {
+          currentSelectedOptions = new Array();
+        }
+
+        for(var i=0; i < options.length; i++) {
+          var selected = '';
+          var checked = '';
+          if (currentSelectedOptions.indexOf(options[i].key) >= 0 || currentSelectedOptions.indexOf(options[i].key.toString()) >= 0) {
+            checked = 'checked="checked"';
+            selectedOptions[selectedOptions.length] = options[i].key;
+          }
+          if (options[i].key == currentSelectedOption || (!currentSelectedOption && i == 0)) {
+            selected='selected="selected"';
+            selectedOption = options[i].key;
+          }
+          multi_select_options = multi_select_options + '<input type="checkbox" value="'+options[i].key+'" '+checked+'>'+options[i].value+'<br>';
+          select_options = select_options + '<option value="'+options[i].key+'" '+selected+'>'+options[i].value+'</option>';
+        }
+
+        // Single value
+        $('#CRM_Resource_DemandCondition_Attribute__value').val(selectedOption);
+        // Debug: Comment the following line to be able to see the textfield/textarea that holds the values
+        $('#CRM_Resource_DemandCondition_Attribute__value').addClass('hiddenElement');
+        $('#value_options').html(select_options);
+        $('#value_options').removeClass('hiddenElement');
+        $('#value_options').change(function() {
+          var value = $(this).val();
+          $('#CRM_Resource_DemandCondition_Attribute__value').val(value);
+        });
+
+        // Multi-value
+        $('#CRM_Resource_DemandCondition_Attribute__multi_value').val(selectedOptions.join('\r\n'));
+        // Debug: Comment the following line to be able to see the textfield/textarea that holds the values
+        $('textarea#CRM_Resource_DemandCondition_Attribute__multi_value').addClass('hiddenElement');
+        $('#multi_value_options').html(multi_select_options);
+        $('#multi_value_options').removeClass('hiddenElement');
+        $('#multi_value_options input[type="checkbox"]').change(function() {
+          var currentOptions = $('#CRM_Resource_DemandCondition_Attribute__multi_value').val().match(/[^\r\n]+/g);
+          if (!currentOptions) {
+            currentOptions = new Array();
+          }
+          var value = $(this).val();
+          var index = currentOptions.indexOf(value);
+          if (this.checked) {
+            if (index < 0) {
+              currentOptions[currentOptions.length] = value;
+              $('#CRM_Resource_DemandCondition_Attribute__multi_value').val(currentOptions.join('\r\n'));
+            }
+          } else {
+            if (index >= 0) {
+              currentOptions.splice(index, 1);
+              $('#CRM_Resource_DemandCondition_Attribute__multi_value').val(currentOptions.join('\r\n'));
+            }
+          }
+        });
+      } else {
+        // TODO: Fill in more information here on what to hide
+        $('#multi_value_parent .content.textarea').removeClass('hiddenElement');
+        $('#CRM_Resource_DemandCondition_Attribute__value').removeClass('hiddenElement');
+        if (!multiple) {
+          $('textarea#CRM_Resource_DemandCondition_Attribute__multi_value').addClass('hiddenElement');
+        }
+      }
+    }
+
+    var all_fields = $('#CRM_Resource_DemandCondition_Attribute__field_name').html();
+    var resource_form_initialOperator;
+
+    $('#CRM_Resource_DemandCondition_Attribute__field_name').change(function() {
+        var entity = 'Contact';
+        var field = $('#CRM_Resource_DemandCondition_Attribute__field_name').val();
+        var field = field.replace($('#entity').val()+'_', "");
+        retrieveOptionsForEntityAndField(entity, field);
+        $('#operator').trigger('change');
+    });
+
+    // Force a re-render of the changes during load/reload
+    $('#entity').trigger('change');
+    $('#CRM_Resource_DemandCondition_Attribute__field_name').trigger('change');
+    $('#CRM_Resource_DemandCondition_Attribute__operator').trigger('change');
+  });
+})(CRM.$, CRM._, CRM.ts('de.systopia.resource'));

--- a/js/condition_rules.js
+++ b/js/condition_rules.js
@@ -92,7 +92,6 @@
           $('#operator option[value="is not one of"').addClass('hiddenElement');
           $('#operator option[value="contains one or more"').addClass('hiddenElement');
           $('#operator option[value="not contains one or more"').addClass('hiddenElement');
-
       }
       else {
 
@@ -178,10 +177,18 @@
       } else {
         // TODO: Fill in more information here on what to hide
         $('#multi_value_parent .content.textarea').removeClass('hiddenElement');
-        $('#CRM_Resource_DemandCondition_Attribute__value').removeClass('hiddenElement');
+        resource_form_initialOperator = $('#CRM_Resource_DemandCondition_Attribute__operator').val();
+        if (resource_form_initialOperator === 'is empty' || resource_form_initialOperator === 'is not empty') {
+          //$('#CRM_Resource_DemandCondition_Attribute__value').addClass('hiddenElement');
+        }
+        else {
+          $('#CRM_Resource_DemandCondition_Attribute__value').removeClass('hiddenElement');
+        }
+
         if (!multiple) {
           $('textarea#CRM_Resource_DemandCondition_Attribute__multi_value').addClass('hiddenElement');
         }
+
       }
     }
 

--- a/templates/CRM/Resource/Form/Condition.tpl
+++ b/templates/CRM/Resource/Form/Condition.tpl
@@ -20,14 +20,29 @@
     <div class="clear"></div>
   </div>
 
-{foreach from=$type_fields item=type_field}
-  <div class="crm-section condition-form-field {$type_field}">
-    <div class="label">{$form.$type_field.label}</div>
-    <div class="content">{$form.$type_field.html}</div>
+  {foreach from=$type_fields item=type_field}
+    <div class="crm-section condition-form-field {$type_field}">
+      {if !in_array($form.$type_field.id, $exclude_labels) }
+        <div class="label">{$form.$type_field.label}</div>
+      {/if}
+      <div class="content">{$form.$type_field.html}</div>
+      <div class="clear"></div>
+    </div>
+  {/foreach}
+
+  <div class="crm-section" id="value_parent">
+    <div class="content">
+      <select id="value_options" class="hiddenElement"></select>
+    </div>
     <div class="clear"></div>
   </div>
-{/foreach}
-
+  <div class="crm-section" id="multi_value_parent">
+    <div class="content textarea">
+    </div>
+    <div id="multi_value_options" class="hiddenElement content">
+    </div>
+    <div class="clear"></div>
+  </div>
 
   <div class="crm-submit-buttons">
       {include file="CRM/common/formButtons.tpl" location="bottom"}

--- a/templates/CRM/Resource/Form/ConditionEdit.tpl
+++ b/templates/CRM/Resource/Form/ConditionEdit.tpl
@@ -16,13 +16,36 @@
 
   <h3>{ts 1=$current_label}Editing "%1"{/ts}</h3>
 
-{foreach from=$type_fields item=type_field}
-  <div class="crm-section unavailability-form-field {$type_field}">
-    <div class="label">{$form.$type_field.label}</div>
-    <div class="content">{$form.$type_field.html}</div>
+  <div class="crm-section">
+    <div class="label">{$form.condition_type.label}</div>
+    <div class="content">{$form.condition_type.html}</div>
     <div class="clear"></div>
   </div>
-{/foreach}
+
+  {foreach from=$type_fields item=type_field}
+    <div class="crm-section condition-form-field {$type_field}">
+      {if !in_array($form.$type_field.id, $exclude_labels) }
+        <div class="label">{$form.$type_field.label}</div>
+      {/if}
+      <div class="content">{$form.$type_field.html}</div>
+      <div class="clear"></div>
+    </div>
+  {/foreach}
+
+  <div class="crm-section" id="value_parent">
+    <div class="content">
+      <select id="value_options" class="hiddenElement"></select>
+    </div>
+    <div class="clear"></div>
+  </div>
+  <div class="crm-section" id="multi_value_parent">
+    <div class="content textarea">
+    </div>
+    <div id="multi_value_options" class="hiddenElement content">
+    </div>
+    <div class="clear"></div>
+  </div>
+
 
   <div class="crm-submit-buttons">
       {include file="CRM/common/formButtons.tpl" location="bottom"}


### PR DESCRIPTION
This PR add UX improvements on the condition type `Attribute value`, as described on issue https://github.com/systopia/de.systopia.resource/issues/29

Improvements:

* Adds the missing functionality for point-and-click actions on the condition type: `Attribute Value`
* Introduces new value operator(s): `Contains one or more string(s) (case insensitive)` & `Does not contain one or more string(s) (case insensitive)` which cover the case of multi-select customfields, as the `is one of` does not apply in the case of customfields with multiselect values.
* Loosely based on CiviRules condition editing
* All conditional actions in jQuery take place in a new file `condition_rules.js` which is being injected on both conditions: adding & editing of the condition.
