### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,13 +14,13 @@
     <url desc="Support">https://github.com/systopia/de.systopia.resource/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate></releaseDate>
+  <releaseDate/>
   <version>1.0-dev</version>
   <develStage>dev</develStage>
   <compatibility>
-    <ver>5.45</ver>
+    <ver>5.65</ver>
   </compatibility>
-  <comments></comments>
+  <comments/>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>
     <psr0 prefix="CRM_" path="."/>

--- a/templates/CRM/Resource/Page/ResourceDemandConditions.tpl
+++ b/templates/CRM/Resource/Page/ResourceDemandConditions.tpl
@@ -31,7 +31,7 @@
     </table>
   </div>
 
-  <h3 class="header-dark resource-demand-view">{ts}Conditions{/ts} <a href="{$condition_create_link}" title="{ts}Add Resource Condition{/ts}" class="crm-popup medium-popup">[+]</a></h3>
+  <h3 class="header-dark resource-demand-view">{ts}Conditions{/ts} <a href="{$condition_create_link}" title="{ts escape='htmlattribute'}Add Resource Condition{/ts}" class="crm-popup medium-popup">[+]</a></h3>
   <div class="resource-demand-view resource-demand-view-conditions">
       {if $conditions}
         <table class="crm-table resource-demand-view resource-demand-view-conditions">
@@ -41,8 +41,8 @@
                 <td>{$condition.display_name}</td>
                 <td class="nowrap">
                     <span>
-                      <a href="{$condition.edit_link}" class="action-item crm-hover-button crm-popup medium-popup" title="{ts}Edit Condition{/ts}">{ts}Edit{/ts}</a>
-                      <a class="action-item crm-hover-button action--resource--demand_condition-delete" data-condition-id="{$condition.id}" title="{ts}Delete Condition{/ts}" href="#">{ts}Delete{/ts}</a>
+                      <a href="{$condition.edit_link}" class="action-item crm-hover-button crm-popup medium-popup" title="{ts escape='htmlattribute'}Edit Condition{/ts}">{ts}Edit{/ts}</a>
+                      <a class="action-item crm-hover-button action--resource--demand_condition-delete" data-condition-id="{$condition.id}" title="{ts escape='htmlattribute'}Delete Condition{/ts}" href="#">{ts}Delete{/ts}</a>
                     </span>
                 </td>
               </tr>

--- a/templates/CRM/Resource/Page/ResourceDemandsView.tpl
+++ b/templates/CRM/Resource/Page/ResourceDemandsView.tpl
@@ -37,23 +37,23 @@
                     <td>{$resource_demand.type_label}</td>
                     <td>
                         {if $resource_demand.assignment_count}
-                          <a href="{$resource_demand.unassign_link}" class="action-item crm-hover-button crm-popup medium-popup" title="{ts}Manage Assignments{/ts}">{$resource_demand.assignment_count} / {$resource_demand.count}</a>
+                          <a href="{$resource_demand.unassign_link}" class="action-item crm-hover-button crm-popup medium-popup" title="{ts escape='htmlattribute'}Manage Assignments{/ts}">{$resource_demand.assignment_count} / {$resource_demand.count}</a>
                         {else}
-                          <span title="{ts}No Assignments{/ts}">{$resource_demand.assignment_count} / {$resource_demand.count}</span>
+                          <span title="{ts escape='htmlattribute'}No Assignments{/ts}">{$resource_demand.assignment_count} / {$resource_demand.count}</span>
                         {/if}
-                        {if $resource_demand.assignment_count gt $resource_demand.count}<i aria-hidden="true" class="crm-i fa-angle-double-up" title="{ts}more resources assigned than required{/ts}">{/if}
+                        {if $resource_demand.assignment_count gt $resource_demand.count}<i aria-hidden="true" class="crm-i fa-angle-double-up" title="{ts escape='htmlattribute'}more resources assigned than required{/ts}">{/if}
                     </td>
-                    <td>{$resource_demand.fulfilled_count} / {$resource_demand.count} {if $resource_demand.fulfilled_count gt $resource_demand.count}<i aria-hidden="true" class="crm-i fa-angle-double-up" title="{ts}more resources assigned than required{/ts}">{/if}</td>
+                    <td>{$resource_demand.fulfilled_count} / {$resource_demand.count} {if $resource_demand.fulfilled_count gt $resource_demand.count}<i aria-hidden="true" class="crm-i fa-angle-double-up" title="{ts escape='htmlattribute'}more resources assigned than required{/ts}">{/if}</td>
                     <td class="nowrap">
                         <span>
-                          <a href="{$resource_demand.conditions_link}" class="action-item crm-hover-button crm-popup medium-popup" title="{ts}Edit Conditions{/ts}">{ts 1=$resource_demand.condition_count}Modify (%1){/ts}</a>
+                          <a href="{$resource_demand.conditions_link}" class="action-item crm-hover-button crm-popup medium-popup" title="{ts escape='htmlattribute'}Edit Conditions{/ts}">{ts 1=$resource_demand.condition_count}Modify (%1){/ts}</a>
                         </span>
                     </td>
                     <td class="nowrap">
                       <span>
-                        <a href="{$resource_demand.assign_link}" class="action-item crm-hover-button crm-popup medium-popup" title="{ts}Assign New Resources{/ts}">{ts}Assign{/ts}</a>
-                        <a href="{$resource_demand.edit_link}" class="action-item crm-hover-button crm-popup small-popup" title="{ts}Edit Resource Demand{/ts}">{ts}Edit{/ts}</a>
-                        <a class="action-item crm-hover-button action--resource--demand-delete" data-demand-id="{$resource_demand.id}" title="{ts}Delete Resource Demand{/ts}">{ts}Delete{/ts}</a>
+                        <a href="{$resource_demand.assign_link}" class="action-item crm-hover-button crm-popup medium-popup" title="{ts escape='htmlattribute'}Assign New Resources{/ts}">{ts}Assign{/ts}</a>
+                        <a href="{$resource_demand.edit_link}" class="action-item crm-hover-button crm-popup small-popup" title="{ts escape='htmlattribute'}Edit Resource Demand{/ts}">{ts}Edit{/ts}</a>
+                        <a class="action-item crm-hover-button action--resource--demand-delete" data-demand-id="{$resource_demand.id}" title="{ts escape='htmlattribute'}Delete Resource Demand{/ts}">{ts}Delete{/ts}</a>
                       </span>
                     </td>
                 </tr>

--- a/templates/CRM/Resource/Page/ResourceView.tpl
+++ b/templates/CRM/Resource/Page/ResourceView.tpl
@@ -14,7 +14,7 @@
 
 {crmScope extensionKey='de.systopia.resource'}
   <div class="crm-block crm-content-block">
-    <h3 class="header-dark resource-view">{ts}Resource Information{/ts} <a href="{$resource_edit_link}" title="{ts}Edit Resource{/ts}" class="crm-popup medium-popup" id="resource--resource--edit">[{ts}edit{/ts}]</a></h3>
+    <h3 class="header-dark resource-view">{ts}Resource Information{/ts} <a href="{$resource_edit_link}" title="{ts escape='htmlattribute'}Edit Resource{/ts}" class="crm-popup medium-popup" id="resource--resource--edit">[{ts}edit{/ts}]</a></h3>
     <div class="crm-container section-shown resource-view resource-view-info">
       <table class="no-border">
         <tr>
@@ -32,7 +32,7 @@
       </table>
     </div>
 
-    <h3 class="header-dark resource-view">{ts}Availability Restrictions{/ts} <a href="{$unavailability_create_link}" title="{ts}Add Availability Restriction{/ts}" class="crm-popup medium-popup" id="resource--unavailability--add">[+]</a></h3>
+    <h3 class="header-dark resource-view">{ts}Availability Restrictions{/ts} <a href="{$unavailability_create_link}" title="{ts escape='htmlattribute'}Add Availability Restriction{/ts}" class="crm-popup medium-popup" id="resource--unavailability--add">[+]</a></h3>
     <div class="crm-container section-shown resource-view resource-view-availabilities">
           <table class="crm-table row-highlight resource-view resource-view-unavailabilities">
               {if $unavailabilities}
@@ -41,8 +41,8 @@
                   <td>{$unavailability.display_name}</td>
                   <td class="nowrap">
                     <span>
-                      <a href="{$unavailability.edit_link}" class="action-item crm-hover-button crm-popup medium-popup" title="{ts}Edit Unavailability{/ts}">{ts}Edit{/ts}</a>
-                      <a class="action-item crm-hover-button action--resource--unavailability-delete" title="{ts}Delete Unavailability{/ts}" data-unavailability-id="{$unavailability.id}">{ts}Delete{/ts}</a>
+                      <a href="{$unavailability.edit_link}" class="action-item crm-hover-button crm-popup medium-popup" title="{ts escape='htmlattribute'}Edit Unavailability{/ts}">{ts}Edit{/ts}</a>
+                      <a class="action-item crm-hover-button action--resource--unavailability-delete" title="{ts escape='htmlattribute'}Delete Unavailability{/ts}" data-unavailability-id="{$unavailability.id}">{ts}Delete{/ts}</a>
                     </span>
                   </td>
                 </tr>
@@ -55,7 +55,7 @@
           </table>
     </div>
 
-    <h3 class="header-dark resource-view">{ts}Assignments{/ts} <a href="{$assignment_create_link}" title="{ts}Assign to Other Demands{/ts}" class="crm-popup small-popup">[+]</a></h3>
+    <h3 class="header-dark resource-view">{ts}Assignments{/ts} <a href="{$assignment_create_link}" title="{ts escape='htmlattribute'}Assign to Other Demands{/ts}" class="crm-popup small-popup">[+]</a></h3>
     <div class="crm-container section-shown resource-view resource-view-assignments">
           <table class="crm-table row-highlight resource-view resource-view-unavailabilities">
               {if $assignments|count}
@@ -66,7 +66,7 @@
                   <td>{$assignment.status}</td>
                   <td class="nowrap">
                     <span>
-                      <a class="action-item crm-hover-button action--resource--assignment-delete" data-assignment-id="{$assignment.assignment_id}" title="{ts}Unassign{/ts}">{ts}Unassign{/ts}</a>
+                      <a class="action-item crm-hover-button action--resource--assignment-delete" data-assignment-id="{$assignment.assignment_id}" title="{ts escape='htmlattribute'}Unassign{/ts}">{ts}Unassign{/ts}</a>
                     </span>
                   </td>
                 </tr>


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.