### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Resource/Form/ResourceAssignmentOptions.php
+++ b/CRM/Resource/Form/ResourceAssignmentOptions.php
@@ -121,7 +121,7 @@ class CRM_Resource_Form_ResourceAssignmentOptions extends CRM_Core_Form
                             'status' => CRM_Resource_BAO_ResourceAssignment::STATUS_CONFIRMED,
                         ]);
                         $success_count++;
-                    } catch (CiviCRM_API3_Exception $ex) {
+                    } catch (CRM_Core_Exception $ex) {
                         $error_messages[$resource_demand_id] = $ex->getMessage();
                     }
                 }

--- a/CRM/Resource/Form/ResourceDemandAssign.php
+++ b/CRM/Resource/Form/ResourceDemandAssign.php
@@ -122,7 +122,7 @@ class CRM_Resource_Form_ResourceDemandAssign extends CRM_Core_Form
                             'status' => CRM_Resource_BAO_ResourceAssignment::STATUS_CONFIRMED,
                         ]);
                         $success_count++;
-                    } catch (CiviCRM_API3_Exception $ex) {
+                    } catch (CRM_Core_Exception $ex) {
                         $error_messages[$resource_id] = $ex->getMessage();
                     }
                 }

--- a/Civi/Api4/Action/Resource/MeetsDemand.php
+++ b/Civi/Api4/Action/Resource/MeetsDemand.php
@@ -75,14 +75,14 @@ class MeetsDemand extends AbstractAction
         $resource = new \CRM_Resource_BAO_Resource();
         $resource->id = $this->id;
         if (!$resource->find(true)) {
-            throw new \API_Exception("A resource with ID [{$this->id}] doesn't exist (any more).");
+            throw new \CRM_Core_Exception("A resource with ID [{$this->id}] doesn't exist (any more).");
         }
 
         // get demand
         $resource_demand = new \CRM_Resource_BAO_ResourceDemand();
         $resource_demand->id = $this->resource_demand_id;
         if (!$resource_demand->find(true)) {
-            throw new \API_Exception("A resource demand with ID [{$this->resource_demand_id}] doesn't exist (any more).");
+            throw new \CRM_Core_Exception("A resource demand with ID [{$this->resource_demand_id}] doesn't exist (any more).");
         }
 
         // check issues

--- a/api/v3/Resource.php
+++ b/api/v3/Resource.php
@@ -36,7 +36,7 @@ function _civicrm_api3_resource_create_spec(&$spec)
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_resource_create($params)
 {
@@ -51,7 +51,7 @@ function civicrm_api3_resource_create($params)
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_resource_delete($params)
 {
@@ -66,7 +66,7 @@ function civicrm_api3_resource_delete($params)
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_resource_get($params)
 {
@@ -113,7 +113,7 @@ function _civicrm_api3_resource_meets_demand_spec(&$spec)
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_resource_meets_demand($params)
 {
@@ -125,14 +125,14 @@ function civicrm_api3_resource_meets_demand($params)
     $resource = new CRM_Resource_BAO_Resource();
     $resource->id = $params['id'];
     if (!$resource->find(true)) {
-        throw new CiviCRM_API3_Exception("A resource with ID [{$params['id']}] doesn't exist (any more).");
+        throw new CRM_Core_Exception("A resource with ID [{$params['id']}] doesn't exist (any more).");
     }
 
     // get demand
     $resource_demand = new CRM_Resource_BAO_ResourceDemand();
     $resource_demand->id = $params['resource_demand_id'];
     if (!$resource_demand->find(true)) {
-        throw new CiviCRM_API3_Exception("A resource demand with ID [{$params['resource_demand_id']}] doesn't exist (any more).");
+        throw new CRM_Core_Exception("A resource demand with ID [{$params['resource_demand_id']}] doesn't exist (any more).");
     }
 
     // check issues

--- a/api/v3/ResourceAssignment.php
+++ b/api/v3/ResourceAssignment.php
@@ -36,7 +36,7 @@ function _civicrm_api3_resource_assignment_create_spec(&$spec)
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_resource_assignment_create($params)
 {
@@ -51,7 +51,7 @@ function civicrm_api3_resource_assignment_create($params)
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_resource_assignment_delete($params)
 {
@@ -66,7 +66,7 @@ function civicrm_api3_resource_assignment_delete($params)
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_resource_assignment_get($params)
 {

--- a/api/v3/ResourceDemand.php
+++ b/api/v3/ResourceDemand.php
@@ -36,7 +36,7 @@ function _civicrm_api3_resource_demand_create_spec(&$spec)
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_resource_demand_create($params)
 {
@@ -51,7 +51,7 @@ function civicrm_api3_resource_demand_create($params)
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_resource_demand_delete($params)
 {
@@ -66,7 +66,7 @@ function civicrm_api3_resource_demand_delete($params)
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_resource_demand_get($params)
 {

--- a/api/v3/ResourceDemandCondition.php
+++ b/api/v3/ResourceDemandCondition.php
@@ -36,7 +36,7 @@ function _civicrm_api3_resource_demand_condition_create_spec(&$spec)
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_resource_demand_condition_create($params)
 {
@@ -51,7 +51,7 @@ function civicrm_api3_resource_demand_condition_create($params)
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_resource_demand_condition_delete($params)
 {
@@ -66,7 +66,7 @@ function civicrm_api3_resource_demand_condition_delete($params)
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_resource_demand_condition_get($params)
 {

--- a/api/v3/ResourceUnavailability.php
+++ b/api/v3/ResourceUnavailability.php
@@ -36,7 +36,7 @@ function _civicrm_api3_resource_unavailability_create_spec(&$spec)
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_resource_unavailability_create($params)
 {
@@ -51,7 +51,7 @@ function civicrm_api3_resource_unavailability_create($params)
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_resource_unavailability_delete($params)
 {
@@ -66,7 +66,7 @@ function civicrm_api3_resource_unavailability_delete($params)
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_resource_unavailability_get($params)
 {

--- a/tests/phpunit/ResourceTestBase.php
+++ b/tests/phpunit/ResourceTestBase.php
@@ -94,7 +94,7 @@ class ResourceTestBase extends TestCase implements HeadlessInterface, HookInterf
                 // run with APIv4
                 try {
                     return civicrm_api4($entity, $action, $params);
-                } catch (API_Exception $ex) {
+                } catch (CRM_Core_Exception $ex) {
                     $this->fail("APIv4 error: ", $ex->getMessage());
                 }
             }


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.