### PR TITLE
Remove commented-out boilerplate

### DIFF
--- a/CRM/Resource/BAO/ResourceAssignment.php
+++ b/CRM/Resource/BAO/ResourceAssignment.php
@@ -21,25 +21,5 @@ class CRM_Resource_BAO_ResourceAssignment extends CRM_Resource_DAO_ResourceAssig
     const STATUS_DENIED = 2;
     const STATUS_CONFIRMED = 3;
 
-    /**
-     * Create a new ResourceAssignment based on array-data
-     *
-     * @param array $params key-value pairs
-     *
-     * @return CRM_Resource_DAO_ResourceAssignment|NULL
-     *
-     * public static function create($params) {
-     * $className = 'CRM_Resource_DAO_ResourceAssignment';
-     * $entityName = 'ResourceAssignment';
-     * $hook = empty($params['id']) ? 'create' : 'edit';
-     *
-     * CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
-     * $instance = new $className();
-     * $instance->copyValues($params);
-     * $instance->save();
-     * CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
-     *
-     * return $instance;
-     * } */
 
 }


### PR DESCRIPTION
Civix used to generate commented-out BAO create functions, however all BAOs now inherit writeRecords() from their parent.

Since this function was never uncommented, it's safe to remove.